### PR TITLE
Add Exact dimensions flag to generate image with precise width and height

### DIFF
--- a/example/assets/invoice.html
+++ b/example/assets/invoice.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+        <title>Receipt example</title>
+        <style>
+            * {
+                font-size: 12px;
+                font-family: "Times New Roman";
+            }
+
+            td,
+            th,
+            tr,
+            table {
+                border-top: 1px solid black;
+                border-collapse: collapse;
+            }
+
+            td.description,
+            th.description {
+                width: 75px;
+                max-width: 75px;
+            }
+
+            td.quantity,
+            th.quantity {
+                width: 40px;
+                max-width: 40px;
+                word-break: break-all;
+            }
+
+            td.price,
+            th.price {
+                width: 40px;
+                max-width: 40px;
+                word-break: break-all;
+            }
+
+            .centered {
+                text-align: center;
+                align-content: center;
+            }
+
+            .ticket {
+                width: 155px;
+                max-width: 155px;
+            }
+
+            img {
+                max-width: inherit;
+                width: inherit;
+            }
+
+            @media print {
+                .hidden-print,
+                .hidden-print * {
+                    display: none !important;
+                }
+            }
+        </style>
+    </head>
+    <body>
+        <div class="ticket">
+            <!-- <img
+                src="https://raw.githubusercontent.com/parzibyte/print-receipt-thermal-printer/refs/heads/master/logo.png"
+                alt="Logo"
+            /> -->
+            <p class="centered">
+                RECEIPT EXAMPLE <br />Address line 1 <br />Address line 2
+            </p>
+            <table>
+                <thead>
+                    <tr>
+                        <th class="quantity">Q.</th>
+                        <th class="description">Description</th>
+                        <th class="price">$$</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="quantity">1.00</td>
+                        <td class="description">ARDUINO UNO R3</td>
+                        <td class="price">$25.00</td>
+                    </tr>
+                    <tr>
+                        <td class="quantity">2.00</td>
+                        <td class="description">JAVASCRIPT BOOK</td>
+                        <td class="price">$10.00</td>
+                    </tr>
+                    <tr>
+                        <td class="quantity">1.00</td>
+                        <td class="description">STICKER PACK</td>
+                        <td class="price">$10.00</td>
+                    </tr>
+                    <tr>
+                        <td class="quantity"></td>
+                        <td class="description">TOTAL</td>
+                        <td class="price">$55.00</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p class="centered">
+                Thanks for your purchase! <br />parzibyte.me/blog
+            </p>
+        </div>
+    </body>
+</html>

--- a/lib/html_to_image.dart
+++ b/lib/html_to_image.dart
@@ -21,6 +21,8 @@ class HtmlToImage {
     int? width,
     Duration delay = const Duration(milliseconds: 200),
     ImageMargins margins = const ImageMargins(),
+    bool useExactDimentions = false,
+    int initialScale = 1,
   }) async {
     final content = await rootBundle.loadString(asset);
     return HtmlToImagePlatform.instance.convertToImage(
@@ -28,6 +30,8 @@ class HtmlToImage {
       width: width,
       delay: delay,
       margins: margins,
+      useExactDimentions: useExactDimentions,
+      initialScale: initialScale,
     );
   }
 
@@ -46,12 +50,16 @@ class HtmlToImage {
     int? width,
     Duration delay = const Duration(milliseconds: 200),
     ImageMargins margins = const ImageMargins(),
+    bool useExactDimentions = false,
+    int initialScale = 1,
   }) {
     return HtmlToImagePlatform.instance.convertToImage(
       content: content,
       delay: delay,
       width: width,
       margins: margins,
+      useExactDimentions: useExactDimentions,
+      initialScale: initialScale,
     );
   }
 
@@ -70,6 +78,8 @@ class HtmlToImage {
     int? width,
     Duration delay = const Duration(milliseconds: 200),
     ImageMargins margins = const ImageMargins(),
+    bool useExactDimentions = false,
+    int initialScale = 1,
   }) async {
     try {
       return await HtmlToImagePlatform.instance.convertToImage(
@@ -77,6 +87,8 @@ class HtmlToImage {
         delay: delay,
         width: width,
         margins: margins,
+        useExactDimentions: useExactDimentions,
+        initialScale: initialScale,
       );
     } catch (_) {
       return null;

--- a/lib/html_to_image.dart
+++ b/lib/html_to_image.dart
@@ -21,7 +21,7 @@ class HtmlToImage {
     int? width,
     Duration delay = const Duration(milliseconds: 200),
     ImageMargins margins = const ImageMargins(),
-    bool useExactDimentions = false,
+    bool useExactDimensions = false,
     int initialScale = 1,
   }) async {
     final content = await rootBundle.loadString(asset);
@@ -30,7 +30,7 @@ class HtmlToImage {
       width: width,
       delay: delay,
       margins: margins,
-      useExactDimentions: useExactDimentions,
+      useExactDimensions: useExactDimensions,
       initialScale: initialScale,
     );
   }
@@ -50,7 +50,7 @@ class HtmlToImage {
     int? width,
     Duration delay = const Duration(milliseconds: 200),
     ImageMargins margins = const ImageMargins(),
-    bool useExactDimentions = false,
+    bool useExactDimensions = false,
     int initialScale = 1,
   }) {
     return HtmlToImagePlatform.instance.convertToImage(
@@ -58,7 +58,7 @@ class HtmlToImage {
       delay: delay,
       width: width,
       margins: margins,
-      useExactDimentions: useExactDimentions,
+      useExactDimensions: useExactDimensions,
       initialScale: initialScale,
     );
   }
@@ -78,7 +78,7 @@ class HtmlToImage {
     int? width,
     Duration delay = const Duration(milliseconds: 200),
     ImageMargins margins = const ImageMargins(),
-    bool useExactDimentions = false,
+    bool useExactDimensions = false,
     int initialScale = 1,
   }) async {
     try {
@@ -87,7 +87,7 @@ class HtmlToImage {
         delay: delay,
         width: width,
         margins: margins,
-        useExactDimentions: useExactDimentions,
+        useExactDimensions: useExactDimensions,
         initialScale: initialScale,
       );
     } catch (_) {

--- a/lib/html_to_image_method_channel.dart
+++ b/lib/html_to_image_method_channel.dart
@@ -16,6 +16,8 @@ class MethodChannelHtmlToImage extends HtmlToImagePlatform {
     int? width,
     Duration delay = const Duration(milliseconds: 200),
     ImageMargins margins = const ImageMargins(),
+    bool useExactDimentions = false,
+    int initialScale = 1,
   }) async {
     final Map<String, dynamic> arguments = {
       'content': content,
@@ -27,6 +29,8 @@ class MethodChannelHtmlToImage extends HtmlToImagePlatform {
         margins.right,
         margins.bottom,
       ],
+      'use_exact_dimensions': useExactDimentions,
+      'initial_scale': initialScale,
     };
     try {
       final result = await (methodChannel.invokeMethod(

--- a/lib/html_to_image_method_channel.dart
+++ b/lib/html_to_image_method_channel.dart
@@ -16,7 +16,7 @@ class MethodChannelHtmlToImage extends HtmlToImagePlatform {
     int? width,
     Duration delay = const Duration(milliseconds: 200),
     ImageMargins margins = const ImageMargins(),
-    bool useExactDimentions = false,
+    bool useExactDimensions = false,
     int initialScale = 1,
   }) async {
     final Map<String, dynamic> arguments = {
@@ -29,7 +29,7 @@ class MethodChannelHtmlToImage extends HtmlToImagePlatform {
         margins.right,
         margins.bottom,
       ],
-      'use_exact_dimensions': useExactDimentions,
+      'use_exact_dimensions': useExactDimensions,
       'initial_scale': initialScale,
     };
     try {

--- a/lib/html_to_image_platform_interface.dart
+++ b/lib/html_to_image_platform_interface.dart
@@ -31,6 +31,8 @@ abstract class HtmlToImagePlatform extends PlatformInterface {
     int? width,
     Duration delay = const Duration(milliseconds: 200),
     ImageMargins margins = const ImageMargins(),
+    bool useExactDimentions = false,
+    int initialScale = 1,
   }) {
     throw UnimplementedError('contentToImage() has not been implemented.');
   }

--- a/lib/html_to_image_platform_interface.dart
+++ b/lib/html_to_image_platform_interface.dart
@@ -31,7 +31,7 @@ abstract class HtmlToImagePlatform extends PlatformInterface {
     int? width,
     Duration delay = const Duration(milliseconds: 200),
     ImageMargins margins = const ImageMargins(),
-    bool useExactDimentions = false,
+    bool useExactDimensions = false,
     int initialScale = 1,
   }) {
     throw UnimplementedError('contentToImage() has not been implemented.');

--- a/test/html_to_image_test.dart
+++ b/test/html_to_image_test.dart
@@ -16,7 +16,7 @@ class MockHtmlToImagePlatform
     int? width,
     Duration delay = const Duration(milliseconds: 200),
     ImageMargins margins = const ImageMargins(),
-    bool useExactDimentions = false,
+    bool useExactDimensions = false,
     int initialScale = 1,
   }) {
     throw UnimplementedError();

--- a/test/html_to_image_test.dart
+++ b/test/html_to_image_test.dart
@@ -16,6 +16,8 @@ class MockHtmlToImagePlatform
     int? width,
     Duration delay = const Duration(milliseconds: 200),
     ImageMargins margins = const ImageMargins(),
+    bool useExactDimentions = false,
+    int initialScale = 1,
   }) {
     throw UnimplementedError();
   }


### PR DESCRIPTION
Added `useExactDimensions` flag to generate image with exact content width and height as the html appears. This will be particularly useful for content with width smaller than the viewport, such as for thermal printing. Fixes #4 